### PR TITLE
Add global theme tokens and refactor section styling

### DIFF
--- a/src/css/About.css
+++ b/src/css/About.css
@@ -4,24 +4,24 @@
   justify-content: center;
   align-items: center;
   padding: 8rem 1.5rem 6rem;
-  background: linear-gradient(180deg, #fefefe, #f1f3f5);
+  background: linear-gradient(180deg, var(--color-neutral-0), var(--color-neutral-50));
   transition: background 0.5s ease;
   min-height: 100vh;
   scroll-margin-top: 80px; /* For smooth scroll behavior */
 }
 
 .about-section:hover {
-  background: linear-gradient(180deg, #f1f3f5, #e3e6ea);
+  background: linear-gradient(180deg, var(--color-neutral-50), var(--color-neutral-100));
 }
 
 .about-content {
   max-width: 1200px;
   width: 100%;
   padding: 2.5rem;
-  background: #ffffff;
+  background: var(--color-neutral-0);
   border-radius: 20px;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-  border: 1px solid #dee2e6;
+  box-shadow: var(--shadow-strong);
+  border: 1px solid var(--color-neutral-300);
   transition: transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
   text-align: center;
   will-change: transform;
@@ -29,8 +29,8 @@
 
 .about-content:hover {
   transform: translateY(-5px);
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.15);
-  border-color: #ced4da;
+  box-shadow: 0 12px 40px color-mix(in srgb, var(--color-primary-500) 18%, var(--color-neutral-900) 20%);
+  border-color: var(--color-neutral-400);
 }
 
 .center-name {
@@ -41,12 +41,17 @@
   font-size: 3.75rem;
   font-weight: 800;
   letter-spacing: 2px;
-  background: linear-gradient(135deg, #ff6600, #ffcc00, #ff0066);
+  background: linear-gradient(
+    135deg,
+    var(--color-primary-500),
+    var(--color-primary-highlight),
+    color-mix(in srgb, var(--color-primary-500) 60%, var(--color-accent-500))
+  );
   background-size: 300% 300%;
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
-  text-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
+  text-shadow: 0 4px 6px color-mix(in srgb, var(--color-primary-500) 18%, var(--color-neutral-900) 25%);
   animation: gradient-shift 6s ease infinite;
   will-change: background-position;
 }
@@ -85,7 +90,7 @@
 .about-left {
   flex: 1;
   text-align: left;
-  color: #333;
+  color: var(--color-neutral-700);
   min-width: 300px;
 }
 
@@ -97,20 +102,20 @@
   font-size: 1.15rem;
   line-height: 1.8;
   margin-bottom: 2rem;
-  color: #444;
+  color: var(--color-neutral-600);
   text-align: justify;
   transition: color 0.3s ease;
 }
 
 .about-description:hover {
-  color: #000;
+  color: var(--color-neutral-900);
 }
 
 .project-list {
   padding-left: 1.5rem;
   margin: 1rem 0;
   list-style-type: disc;
-  color: #333;
+  color: var(--color-neutral-700);
 }
 
 .project-list li {
@@ -120,7 +125,7 @@
 }
 
 .project-list li::marker {
-  color: #ff6600;
+  color: var(--color-primary-500);
 }
 
 .about-right {
@@ -135,7 +140,7 @@
   width: 100%;
   max-width: 320px;
   border-radius: 50%;
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 12px 30px color-mix(in srgb, var(--color-primary-500) 20%, var(--color-neutral-900) 25%);
   transition: transform 0.4s ease, filter 0.4s ease;
   will-change: transform;
   aspect-ratio: 1;
@@ -228,7 +233,7 @@
 }
 
 .modern-about {
-  background: #f7f7fa;
+  background: var(--surface-muted);
   min-height: 100vh;
   display: flex;
   align-items: center;
@@ -237,9 +242,9 @@
 }
 
 .about-card {
-  background: #fff;
+  background: var(--color-neutral-0);
   border-radius: 20px;
-  box-shadow: 0 4px 24px rgba(0,0,0,0.08);
+  box-shadow: var(--shadow-soft);
   max-width: 900px;
   width: 100%;
   margin: 0 auto;
@@ -267,9 +272,9 @@
   height: 180px;
   border-radius: 50%;
   object-fit: cover;
-  border: 3px solid #ff6600;
-  box-shadow: 0 2px 12px rgba(0,0,0,0.07);
-  background: #fff;
+  border: 3px solid var(--color-primary-500);
+  box-shadow: 0 2px 12px color-mix(in srgb, var(--color-primary-500) 18%, var(--color-neutral-900) 12%);
+  background: var(--color-neutral-0);
 }
 
 .about-info {
@@ -291,7 +296,7 @@
 .about-name-modern {
   font-size: 2.1rem;
   font-weight: 800;
-  color: #222;
+  color: var(--color-neutral-800);
   margin-bottom: 0.3rem;
   letter-spacing: 1px;
   text-align: center;
@@ -304,13 +309,13 @@
   margin: 0.5rem auto 0 auto;
   width: 48px;
   height: 3px;
-  background: #ff6600;
+  background: var(--color-primary-500);
   border-radius: 2px;
 }
 
 .about-title {
   font-size: 1.05rem;
-  color: #ff6600;
+  color: var(--color-primary-500);
   font-weight: 600;
   margin-top: 0.2rem;
   letter-spacing: 0.5px;
@@ -320,7 +325,7 @@
 .about-text-modern {
   width: 100%;
   font-size: 1.08rem;
-  color: #333;
+  color: var(--color-neutral-700);
   line-height: 1.7;
   text-align: left;
   margin-bottom: 1.2rem;
@@ -328,24 +333,24 @@
 }
 
 .about-text-modern .about-description {
-  color: #444;
+  color: var(--color-neutral-600);
   margin-bottom: 1.1rem;
   font-size: 1.08rem;
   text-align: justify;
 }
 
 .about-text-modern .about-description strong {
-  color: #ff6600;
+  color: var(--color-primary-500);
   font-weight: 600;
 }
 
 .about-projects .project-list {
   margin: 0.5rem 0 1.1rem 1.1rem;
-  color: #333;
+  color: var(--color-neutral-700);
 }
 
 .about-projects .project-list li::marker {
-  color: #ff6600;
+  color: var(--color-primary-500);
 }
 
 /* Responsive Design */

--- a/src/css/Certifications.css
+++ b/src/css/Certifications.css
@@ -2,9 +2,9 @@
 .certifications-section {
   padding: 5rem 2rem;
   text-align: center;
-  background: radial-gradient(circle, #f3f8ff, #e0f0ff);
+  background: radial-gradient(circle, var(--color-neutral-50), color-mix(in srgb, var(--color-accent-50) 60%, var(--color-neutral-0)));
   border-radius: 16px;
-  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-strong);
   position: relative;
   z-index: 1;
 }
@@ -12,7 +12,7 @@
 .certifications-section h1 {
   font-size: 3rem;
   font-weight: bold;
-  color: #003366;
+  color: color-mix(in srgb, var(--color-accent-600) 70%, var(--color-neutral-900));
   text-transform: uppercase;
   letter-spacing: 2px;
   margin-bottom: 2rem;
@@ -27,7 +27,7 @@
   transform: translateX(-50%);
   width: 50%;
   height: 4px;
-  background: linear-gradient(90deg, #007bff, #00c6ff);
+  background: linear-gradient(90deg, var(--color-accent-500), var(--color-accent-400));
   border-radius: 2px;
 }
 
@@ -47,7 +47,7 @@
   transform: translateX(-50%);
   width: 4px;
   height: 100%;
-  background: linear-gradient(180deg, #007bff, #00c6ff);
+  background: linear-gradient(180deg, var(--color-accent-500), var(--color-accent-400));
   border-radius: 2px;
   opacity: 0.3;
 }
@@ -55,9 +55,9 @@
 .certification-item {
   display: flex;
   align-items: flex-start;
-  background: rgba(255, 255, 255, 0.95);
+  background: color-mix(in srgb, var(--color-neutral-0) 95%, transparent);
   border-radius: 16px;
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 8px 20px color-mix(in srgb, var(--color-accent-500) 15%, var(--color-neutral-900) 15%);
   padding: 2rem;
   width: 80%;
   max-width: 600px;
@@ -69,32 +69,32 @@
 
 .certification-item:hover {
   transform: translateY(-8px) scale(1.02);
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 12px 32px color-mix(in srgb, var(--color-accent-500) 25%, var(--color-neutral-900) 20%);
 }
 
 .certification-item.in-progress {
-  border-left: 4px solid #ffd700;
+  border-left: 4px solid var(--color-warning);
 }
 
 .certification-item.completed {
-  border-left: 4px solid #28a745;
+  border-left: 4px solid var(--color-success);
 }
 
 .certification-icon {
-  background: linear-gradient(135deg, #007bff, #00c6ff);
-  color: #fff;
+  background: linear-gradient(135deg, var(--color-accent-500), var(--color-accent-400));
+  color: var(--color-neutral-0);
   border-radius: 50%;
   padding: 1rem;
   font-size: 2rem;
   margin-right: 2rem;
   flex-shrink: 0;
-  box-shadow: 0 6px 15px rgba(0, 123, 255, 0.5);
+  box-shadow: 0 6px 15px color-mix(in srgb, var(--color-accent-500) 35%, transparent);
   transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .certification-icon:hover {
   transform: scale(1.2) rotate(10deg);
-  box-shadow: 0 8px 20px rgba(0, 123, 255, 0.7);
+  box-shadow: 0 8px 20px color-mix(in srgb, var(--color-accent-500) 45%, transparent);
 }
 
 .certification-content {
@@ -104,13 +104,13 @@
 
 .certification-content h3 {
   font-size: 1.8rem;
-  color: #222;
+  color: var(--color-neutral-800);
   margin-bottom: 0.5rem;
 }
 
 .credential-id {
   font-size: 1rem;
-  color: #666;
+  color: var(--text-muted);
   margin-bottom: 0.5rem;
   font-family: monospace;
 }
@@ -118,7 +118,7 @@
 .issued-date,
 .estimated-completion {
   font-size: 1.1rem;
-  color: #555;
+  color: var(--color-neutral-600);
   font-style: italic;
   margin-bottom: 0.5rem;
 }
@@ -126,24 +126,24 @@
 .view-credential {
   display: inline-block;
   font-size: 1.1rem;
-  color: #007bff;
+  color: var(--color-accent-500);
   text-decoration: none;
   margin-top: 1rem;
   padding: 0.5rem 1rem;
-  border: 2px solid #007bff;
+  border: 2px solid var(--color-accent-500);
   border-radius: 8px;
   transition: all 0.3s ease;
 }
 
 .view-credential:hover {
-  background-color: #007bff;
-  color: white;
+  background-color: var(--color-accent-500);
+  color: var(--color-neutral-0);
   transform: translateY(-2px);
 }
 
 .progress-indicator {
   margin-top: 1rem;
-  background-color: #e9ecef;
+  background-color: var(--color-neutral-200);
   border-radius: 8px;
   height: 8px;
   overflow: hidden;
@@ -151,7 +151,7 @@
 
 .progress-bar {
   height: 100%;
-  background: linear-gradient(90deg, #007bff, #00c6ff);
+  background: linear-gradient(90deg, var(--color-accent-500), var(--color-accent-400));
   border-radius: 8px;
   transition: width 0.5s ease;
   animation: progress-animation 2s ease-in-out infinite;
@@ -227,7 +227,7 @@
 
   .certification-item {
     box-shadow: none;
-    border: 1px solid #ddd;
+    border: 1px solid var(--color-neutral-300);
   }
 
   .certification-icon {

--- a/src/css/ContactForm.css
+++ b/src/css/ContactForm.css
@@ -1,16 +1,3 @@
-/* Global Reset */
-* {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
-
-body {
-  font-family: 'Helvetica Neue', sans-serif;
-  background-color: #fafafa;
-  color: #444;
-}
-
 /* Contact Section */
 #contact {
   display: flex;
@@ -19,7 +6,7 @@ body {
   align-items: center;
   min-height: 100vh;
   padding: 3rem;
-  background-color: #eef3f8;
+  background-color: color-mix(in srgb, var(--color-accent-50) 60%, var(--color-neutral-0));
   position: relative;
 }
 
@@ -29,7 +16,7 @@ body {
   font-size: 2.5rem;
   font-weight: 700;
   margin-bottom: 2.5rem;
-  color: #333;
+  color: var(--color-neutral-700);
   text-transform: uppercase;
   letter-spacing: 1.5px;
   position: relative;
@@ -40,7 +27,7 @@ body {
   position: absolute;
   width: 60%;
   height: 3px;
-  background-color: #00bcd4;
+  background-color: var(--color-accent-500);
   bottom: -10px;
   left: 50%;
   transform: translateX(-50%);
@@ -48,28 +35,28 @@ body {
 
 /* Form Styles */
 .contact-form {
-  background: #ffffff;
+  background: var(--color-neutral-0);
   padding: 2.5rem;
   border-radius: 15px;
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-soft);
   max-width: 600px;
   width: 100%;
   box-sizing: border-box;
   transition: all 0.3s ease-in-out;
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-neutral-300);
   margin: 0 auto;
   padding: 2rem;
 }
 
 .contact-form:hover {
   transform: translateY(-8px);
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 10px 30px color-mix(in srgb, var(--color-accent-500) 12%, var(--color-neutral-900) 20%);
 }
 
 .contact-form h2 {
   font-size: 1.8rem;
   margin-bottom: 1.5rem;
-  color: #333;
+  color: var(--color-neutral-700);
 }
 
 /* Form Fields */
@@ -87,7 +74,7 @@ body {
 .form-group textarea {
   width: 100%;
   padding: 0.75rem;
-  border: 1px solid #ccc;
+  border: 1px solid var(--color-neutral-300);
   border-radius: 4px;
   font-size: 1rem;
 }
@@ -98,7 +85,7 @@ body {
 }
 
 .error-message {
-  color: #dc3545;
+  color: var(--color-danger);
   font-size: 0.875rem;
   margin-top: 0.25rem;
   display: block;
@@ -106,13 +93,13 @@ body {
 
 .form-group input:invalid,
 .form-group textarea:invalid {
-  border-color: #dc3545;
+  border-color: var(--color-danger);
 }
 
 /* Button Styles */
 button[type="submit"] {
-  background-color: #007bff;
-  color: white;
+  background-color: var(--color-accent-500);
+  color: var(--color-neutral-0);
   padding: 0.75rem 1.5rem;
   border: none;
   border-radius: 4px;
@@ -122,18 +109,18 @@ button[type="submit"] {
 }
 
 button[type="submit"]:hover {
-  background-color: #0056b3;
+  background-color: var(--color-accent-600);
 }
 
 button[type="submit"]:disabled {
-  background-color: #ccc;
+  background-color: var(--color-neutral-300);
   cursor: not-allowed;
 }
 
 /* Accessibility focus styles */
 .form-group input:focus,
 .form-group textarea:focus {
-  outline: 2px solid #007bff;
+  outline: 2px solid var(--color-accent-500);
   outline-offset: 2px;
 }
 
@@ -157,7 +144,7 @@ button[type="submit"][aria-busy="true"]::before {
   transform: translateY(-50%);
   width: 1rem;
   height: 1rem;
-  border: 2px solid #fff;
+  border: 2px solid var(--color-neutral-0);
   border-top-color: transparent;
   border-radius: 50%;
   animation: spin 1s linear infinite;

--- a/src/css/DownloadButton.css
+++ b/src/css/DownloadButton.css
@@ -11,22 +11,22 @@
   padding: 12px 24px;
   font-size: 18px;
   font-weight: bold;
-  color: #fff;
-  background: linear-gradient(135deg, #007bff, #0056b3);
+  color: var(--color-neutral-0);
+  background: linear-gradient(135deg, var(--color-accent-500), var(--color-accent-600));
   border: none;
   border-radius: 50px;
   text-decoration: none;
-  box-shadow: 0px 4px 15px rgba(0, 123, 255, 0.5);
+  box-shadow: 0px 4px 15px color-mix(in srgb, var(--color-accent-500) 40%, transparent);
   transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
 }
 
 .download-button:hover {
-  background: linear-gradient(135deg, #0056b3, #004494);
+  background: linear-gradient(135deg, var(--color-accent-600), color-mix(in srgb, var(--color-accent-500) 80%, var(--color-neutral-900)));
   transform: scale(1.05);
-  box-shadow: 0px 8px 20px rgba(0, 123, 255, 0.7);
+  box-shadow: 0px 8px 20px color-mix(in srgb, var(--color-accent-500) 55%, transparent);
 }
 
 .download-button:active {
   transform: scale(0.98);
-  box-shadow: 0px 4px 10px rgba(0, 123, 255, 0.5);
+  box-shadow: 0px 4px 10px color-mix(in srgb, var(--color-accent-500) 40%, transparent);
 }

--- a/src/css/Education.css
+++ b/src/css/Education.css
@@ -1,13 +1,18 @@
 /* Education Section Styles */
 #education {
   padding: 5rem 2rem;
-  background: linear-gradient(135deg, #ffffff 0%, #f8f9fa 100%);
+  background: linear-gradient(
+    135deg,
+    var(--color-neutral-0) 0%,
+    var(--color-neutral-50) 100%
+  );
   position: relative;
   overflow: hidden;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
   justify-content: center;
+  color: var(--color-neutral-700);
 }
 
 #education::before {
@@ -17,9 +22,9 @@
   left: 0;
   right: 0;
   height: 1px;
-  background: linear-gradient(90deg, 
-    transparent 0%, 
-    var(--primary-color) 50%, 
+  background: linear-gradient(90deg,
+    transparent 0%,
+    var(--color-primary-500) 50%,
     transparent 100%
   );
   animation: shimmer 2s infinite;
@@ -32,9 +37,9 @@
   left: 0;
   right: 0;
   height: 1px;
-  background: linear-gradient(90deg, 
-    transparent 0%, 
-    var(--primary-color) 50%, 
+  background: linear-gradient(90deg,
+    transparent 0%,
+    var(--color-primary-500) 50%,
     transparent 100%
   );
   animation: shimmer 2s infinite reverse;
@@ -49,13 +54,13 @@
 #education h1 {
   text-align: center;
   font-size: 3.5rem;
-  color: var(--text-color);
+  color: var(--color-neutral-800);
   margin-bottom: 3rem;
   position: relative;
   text-transform: uppercase;
   letter-spacing: 3px;
   font-weight: 800;
-  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
+  text-shadow: 2px 2px 4px color-mix(in srgb, var(--color-primary-500) 15%, var(--color-neutral-900) 15%);
 }
 
 #education h1::after {
@@ -66,7 +71,7 @@
   transform: translateX(-50%);
   width: 60px;
   height: 4px;
-  background: linear-gradient(90deg, var(--primary-color), var(--primary-dark));
+  background: linear-gradient(90deg, var(--color-primary-500), var(--color-primary-600));
   border-radius: 2px;
   animation: expandWidth 0.6s ease-out forwards;
 }
@@ -87,16 +92,16 @@
 }
 
 .education-card {
-  background: rgba(255, 255, 255, 0.95);
+  background: color-mix(in srgb, var(--color-neutral-0) 95%, transparent);
   border-radius: 20px;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-strong);
   overflow: hidden;
   transition: all 0.5s cubic-bezier(0.4, 0, 0.2, 1);
   transform-style: preserve-3d;
   animation: fadeInUp 0.8s ease-out forwards;
   opacity: 0;
   backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  border: 1px solid color-mix(in srgb, var(--color-neutral-0) 25%, transparent);
 }
 
 .education-card:nth-child(1) { animation-delay: 0.2s; }
@@ -115,19 +120,19 @@
 
 .education-card:hover {
   transform: translateY(-10px) rotateX(5deg);
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 20px 40px color-mix(in srgb, var(--color-primary-500) 18%, var(--color-neutral-900) 25%);
 }
 
 .education-card-header {
-  background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
-  color: var(--text-color);
+  background: linear-gradient(135deg, var(--color-neutral-50) 0%, var(--color-neutral-200) 100%);
+  color: var(--color-neutral-700);
   padding: 2rem;
   display: flex;
   align-items: center;
   gap: 1.5rem;
   position: relative;
   overflow: hidden;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-neutral-400) 25%, transparent);
 }
 
 .education-card-header::before {
@@ -137,9 +142,9 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: linear-gradient(45deg, 
-    rgba(var(--primary-rgb), 0.05) 0%, 
-    rgba(var(--primary-rgb), 0) 100%
+  background: linear-gradient(45deg,
+    color-mix(in srgb, var(--color-primary-500) 5%, transparent) 0%,
+    transparent 100%
   );
   z-index: 1;
   animation: shine 3s infinite;
@@ -151,7 +156,7 @@
 }
 
 .institution-icon {
-  background: rgba(var(--primary-rgb), 0.1);
+  background: color-mix(in srgb, var(--color-primary-500) 12%, transparent);
   width: 60px;
   height: 60px;
   border-radius: 15px;
@@ -162,15 +167,15 @@
   position: relative;
   z-index: 2;
   transition: all 0.4s ease;
-  color: var(--primary-color);
-  box-shadow: 0 4px 15px rgba(var(--primary-rgb), 0.1);
-  border: 1px solid rgba(var(--primary-rgb), 0.2);
+  color: var(--color-primary-500);
+  box-shadow: 0 4px 15px color-mix(in srgb, var(--color-primary-500) 15%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-primary-500) 25%, transparent);
 }
 
 .education-card:hover .institution-icon {
   transform: scale(1.1) rotate(5deg);
-  background: rgba(var(--primary-rgb), 0.15);
-  box-shadow: 0 6px 20px rgba(var(--primary-rgb), 0.2);
+  background: color-mix(in srgb, var(--color-primary-500) 18%, transparent);
+  box-shadow: 0 6px 20px color-mix(in srgb, var(--color-primary-500) 25%, transparent);
 }
 
 .institution-info {
@@ -183,7 +188,7 @@
   margin: 0;
   font-size: 1.4rem;
   font-weight: 700;
-  color: var(--primary-color);
+  color: var(--color-primary-500);
   letter-spacing: 0.5px;
 }
 
@@ -193,13 +198,13 @@
   gap: 0.8rem;
   margin-top: 0.8rem;
   font-size: 1rem;
-  color: var(--text-color);
+  color: var(--color-neutral-700);
 }
 
 .degree-icon {
   font-size: 1.2rem;
   transition: all 0.4s ease;
-  color: var(--primary-color);
+  color: var(--color-primary-500);
 }
 
 .education-card:hover .degree-icon {
@@ -208,7 +213,7 @@
 
 .education-card-body {
   padding: 2rem;
-  background: linear-gradient(to bottom, rgba(255, 255, 255, 0.95) 0%, rgba(250, 250, 250, 0.95) 100%);
+  background: linear-gradient(to bottom, color-mix(in srgb, var(--color-neutral-0) 95%, transparent) 0%, color-mix(in srgb, var(--color-neutral-50) 95%, transparent) 100%);
   position: relative;
 }
 
@@ -218,14 +223,14 @@
   gap: 1rem;
   margin-bottom: 2rem;
   padding-bottom: 2rem;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-neutral-400) 20%, transparent);
 }
 
 .detail-item {
   display: flex;
   align-items: center;
   gap: 1rem;
-  color: var(--text-color);
+  color: var(--color-neutral-700);
   transition: all 0.4s ease;
   padding: 0.5rem;
   border-radius: 8px;
@@ -233,11 +238,11 @@
 
 .detail-item:hover {
   transform: translateX(8px);
-  background: rgba(var(--primary-rgb), 0.05);
+  background: color-mix(in srgb, var(--color-primary-500) 8%, transparent);
 }
 
 .detail-icon {
-  color: var(--primary-color);
+  color: var(--color-primary-500);
   font-size: 1.2rem;
   transition: all 0.4s ease;
 }
@@ -247,7 +252,7 @@
 }
 
 .coursework-section h4 {
-  color: var(--text-color);
+  color: var(--color-neutral-700);
   margin: 0 0 1.5rem 0;
   font-size: 1.2rem;
   position: relative;
@@ -262,7 +267,7 @@
   left: 0;
   width: 100%;
   height: 2px;
-  background: linear-gradient(90deg, var(--primary-color), transparent);
+  background: linear-gradient(90deg, var(--color-primary-500), transparent);
   transform: scaleX(0);
   transform-origin: left;
   transition: transform 0.4s ease;
@@ -279,16 +284,16 @@
 }
 
 .course-item {
-  background: rgba(248, 249, 250, 0.8);
+  background: color-mix(in srgb, var(--color-neutral-50) 80%, transparent);
   padding: 1rem;
   border-radius: 12px;
   font-size: 0.95rem;
-  color: var(--text-color);
+  color: var(--color-neutral-700);
   text-align: center;
   transition: all 0.4s ease;
   position: relative;
   overflow: hidden;
-  border: 1px solid rgba(0, 0, 0, 0.05);
+  border: 1px solid color-mix(in srgb, var(--color-neutral-400) 15%, transparent);
   backdrop-filter: blur(5px);
 }
 
@@ -299,18 +304,18 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background: linear-gradient(45deg, 
-    rgba(var(--primary-rgb), 0.1) 0%, 
-    rgba(var(--primary-rgb), 0) 100%
+  background: linear-gradient(45deg,
+    color-mix(in srgb, var(--color-primary-500) 10%, transparent) 0%,
+    transparent 100%
   );
   opacity: 0;
   transition: opacity 0.4s ease;
 }
 
 .course-item:hover {
-  background: rgba(233, 236, 239, 0.9);
+  background: color-mix(in srgb, var(--color-neutral-200) 90%, transparent);
   transform: translateY(-3px);
-  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 5px 15px color-mix(in srgb, var(--color-primary-500) 12%, var(--color-neutral-900) 15%);
 }
 
 .course-item:hover::before {

--- a/src/css/Experience.css
+++ b/src/css/Experience.css
@@ -1,10 +1,14 @@
 /* Experience Section */
 #experience {
   padding: 4rem 1.5rem 3rem;
-  background: linear-gradient(135deg, #f7faff 0%, #e0ecff 100%);
-  color: #333;
+  background: linear-gradient(
+    135deg,
+    var(--color-neutral-50) 0%,
+    color-mix(in srgb, var(--color-accent-50) 55%, var(--color-neutral-0)) 100%
+  );
+  color: var(--color-neutral-700);
   border-radius: 18px;
-  box-shadow: 0 8px 32px rgba(0,0,0,0.07);
+  box-shadow: var(--shadow-strong);
   margin: 2rem auto;
   max-width: 1400px;
 }
@@ -13,7 +17,7 @@
   text-align: center;
   font-size: 2.3rem;
   font-weight: 800;
-  color: #ff6600;
+  color: var(--color-primary-500);
   margin-bottom: 2.5rem;
   letter-spacing: 1.5px;
   position: relative;
@@ -29,11 +33,11 @@
 
 /* Experience Item */
 .experience-item {
-  background: rgba(255,255,255,0.75);
+  background: color-mix(in srgb, var(--color-neutral-0) 80%, transparent);
   border-radius: 20px;
-  box-shadow: 0 6px 24px rgba(255,102,0,0.07);
+  box-shadow: 0 6px 24px color-mix(in srgb, var(--color-primary-500) 12%, transparent);
   backdrop-filter: blur(8px);
-  border: 1.5px solid rgba(255,102,0,0.08);
+  border: 1.5px solid color-mix(in srgb, var(--color-primary-500) 15%, transparent);
   padding: 2.2rem 1.5rem 1.5rem 1.5rem;
   transition: transform 0.35s cubic-bezier(0.4,0,0.2,1), box-shadow 0.35s, border 0.35s;
   position: relative;
@@ -52,21 +56,21 @@
   top: 0;
   width: 6px;
   height: 100%;
-  background: linear-gradient(180deg, #ff6600 0%, #ffcc00 100%);
+  background: linear-gradient(180deg, var(--color-primary-500) 0%, var(--color-primary-highlight) 100%);
   border-radius: 20px 0 0 20px;
   opacity: 0.85;
 }
 
 .experience-item:hover {
   transform: translateY(-8px) scale(1.025);
-  box-shadow: 0 12px 36px rgba(255,102,0,0.13);
-  border: 1.5px solid #ff6600;
+  box-shadow: 0 12px 36px color-mix(in srgb, var(--color-primary-500) 20%, transparent);
+  border: 1.5px solid var(--color-primary-500);
 }
 
 .experience-item h3 {
   font-size: 1.35rem;
   font-weight: 700;
-  color: #222;
+  color: var(--color-neutral-800);
   margin-bottom: 0.3rem;
   margin-top: 0.2rem;
   position: relative;
@@ -78,7 +82,7 @@
   display: block;
   width: 38px;
   height: 3px;
-  background: #ff6600;
+  background: var(--color-primary-500);
   border-radius: 2px;
   margin-top: 0.4rem;
 }
@@ -86,7 +90,7 @@
 /* Experience Item Text */
 .experience-item .experience-company {
   font-weight: bold;
-  color: #ff6600;
+  color: var(--color-primary-500);
   font-size: 1.08rem;
   margin-bottom: 0.1rem;
   margin-top: 0.2rem;
@@ -94,7 +98,7 @@
 
 .experience-item .experience-duration {
   font-style: italic;
-  color: #888;
+  color: var(--text-muted);
   font-size: 0.98rem;
   margin-bottom: 0.7rem;
 }
@@ -102,7 +106,7 @@
 /* Description and Impact */
 .experience-description h4 {
   font-size: 1.01rem;
-  color: #444;
+  color: var(--color-neutral-600);
   margin-bottom: 0.3rem;
   margin-top: 0.7rem;
 }
@@ -115,14 +119,14 @@
 
 .description-item {
   margin: 8px 0;
-  color: #444;
+  color: var(--color-neutral-600);
   display: flex;
   align-items: flex-start;
   font-size: 1.01rem;
 }
 
 .description-item .icon {
-  color: #ff6600;
+  color: var(--color-primary-500);
   margin-right: 12px;
   font-size: 1.15rem;
   margin-top: 0.1em;
@@ -134,19 +138,19 @@
 .experience-impact {
   margin-top: 1.1rem;
   font-style: italic;
-  background: linear-gradient(90deg, #fffbe6 0%, #ffe0b2 100%);
-  color: #b26a00;
+  background: linear-gradient(90deg, var(--color-primary-soft) 0%, var(--color-primary-100) 100%);
+  color: var(--color-primary-700);
   padding: 0.7em 1em;
   border-radius: 12px;
   font-weight: 600;
-  box-shadow: 0 2px 8px rgba(255,102,0,0.07);
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--color-primary-500) 15%, transparent);
   display: flex;
   align-items: center;
   gap: 0.5em;
 }
 
 .experience-impact .impact-icon {
-  color: #ffa726;
+  color: var(--color-primary-highlight);
   margin-right: 8px;
 }
 
@@ -164,14 +168,14 @@
 }
 
 .technology-item {
-  background: linear-gradient(90deg, #ff6600 0%, #ffcc00 100%);
-  color: #fff;
+  background: linear-gradient(90deg, var(--color-primary-500) 0%, var(--color-primary-highlight) 100%);
+  color: var(--color-neutral-0);
   font-size: 0.87rem;
   padding: 0.32rem 1.1rem;
   border-radius: 16px;
   font-weight: 600;
   letter-spacing: 0.5px;
-  box-shadow: 0 2px 8px rgba(255,102,0,0.07);
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--color-primary-500) 15%, transparent);
   border: none;
   transition: background 0.3s, color 0.3s, box-shadow 0.3s;
   cursor: default;
@@ -179,9 +183,9 @@
 }
 
 .technology-item:hover {
-  background: linear-gradient(90deg, #ffcc00 0%, #ff6600 100%);
-  color: #fffbe6;
-  box-shadow: 0 4px 16px rgba(255,102,0,0.13);
+  background: linear-gradient(90deg, var(--color-primary-highlight) 0%, var(--color-primary-500) 100%);
+  color: var(--color-primary-soft);
+  box-shadow: 0 4px 16px color-mix(in srgb, var(--color-primary-500) 20%, transparent);
 }
 
 /* Responsive Design */

--- a/src/css/Footer.css
+++ b/src/css/Footer.css
@@ -1,29 +1,10 @@
-/* Global Reset */
-* {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
-
-body {
-  font-family: 'Roboto', sans-serif;
-  background-color: #f4f4f4;
-}
-
-/* Add smooth scrolling to the entire page */
-html {
-  scroll-behavior: smooth;
-  scroll-padding-top: 80px; /* Adjust this value based on your header height */
-}
-
-/* Footer Container */
 .footer {
-  background: #121212;
-  color: #f1f1f1;
-  padding: 4rem 2rem 2rem;
+  background: var(--surface-inverse);
+  color: var(--text-on-inverse);
+  padding: var(--space-2xl) var(--space-xl) var(--space-lg);
   position: relative;
-  font-family: 'Roboto', sans-serif;
-  box-shadow: 0 -10px 30px rgba(0, 0, 0, 0.1);
+  font-family: var(--font-family-base);
+  box-shadow: 0 -10px 30px color-mix(in srgb, var(--surface-inverse) 20%, var(--color-neutral-900) 25%);
 }
 
 .footer-content {
@@ -34,8 +15,8 @@ html {
 .footer-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 2rem;
-  margin-bottom: 3rem;
+  gap: var(--space-xl);
+  margin-bottom: var(--space-2xl);
 }
 
 /* Footer Sections */
@@ -44,8 +25,9 @@ html {
 }
 
 .footer-section h3 {
-  color: #00bcd4;
-  font-size: 1.5rem;
+  color: var(--color-accent-500);
+  font-family: var(--font-family-heading);
+  font-size: var(--font-size-xl);
   margin-bottom: 1.5rem;
   position: relative;
   padding-bottom: 0.5rem;
@@ -58,7 +40,7 @@ html {
   bottom: 0;
   width: 50px;
   height: 2px;
-  background: linear-gradient(90deg, #00bcd4, transparent);
+  background: linear-gradient(90deg, var(--color-accent-500), transparent);
 }
 
 /* Contact Info */
@@ -92,7 +74,7 @@ html {
   left: 0;
   width: 0;
   height: 2px;
-  background: #00bcd4;
+  background: var(--color-accent-500);
   transition: width 0.3s ease;
 }
 
@@ -110,7 +92,7 @@ html {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  color: #f1f1f1;
+  color: var(--text-on-inverse);
   text-decoration: none;
   transition: all 0.3s ease;
   padding: 0.5rem;
@@ -118,14 +100,14 @@ html {
 }
 
 .social-link:hover {
-  color: #00bcd4;
+  color: var(--color-accent-500);
   transform: translateY(-3px);
-  background: rgba(0, 188, 212, 0.1);
+  background: color-mix(in srgb, var(--color-accent-500) 15%, transparent);
 }
 
 /* Footer Links */
 .footer-link {
-  color: #f1f1f1;
+  color: var(--text-on-inverse);
   text-decoration: none;
   transition: all 0.3s ease;
   display: flex;
@@ -136,15 +118,15 @@ html {
 }
 
 .footer-link:hover {
-  color: #00bcd4;
+  color: var(--color-accent-500);
   transform: translateX(5px);
-  background: rgba(0, 188, 212, 0.1);
+  background: color-mix(in srgb, var(--color-accent-500) 15%, transparent);
 }
 
 /* Icons */
 .footer-icon {
   font-size: 1.5rem;
-  color: #00bcd4;
+  color: var(--color-accent-500);
   transition: all 0.3s ease;
 }
 
@@ -152,8 +134,8 @@ html {
 .footer-bottom {
   text-align: center;
   padding-top: 2rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
-  color: #888;
+  border-top: 1px solid color-mix(in srgb, var(--text-on-inverse) 15%, transparent);
+  color: var(--text-muted-inverse);
   font-size: 0.9rem;
 }
 
@@ -162,8 +144,8 @@ html {
   position: fixed;
   bottom: 2rem;
   right: 2rem;
-  background: #00bcd4;
-  color: white;
+  background: var(--color-accent-500);
+  color: var(--color-neutral-0);
   width: 45px;
   height: 45px;
   border-radius: 50%;
@@ -173,14 +155,14 @@ html {
   align-items: center;
   justify-content: center;
   transition: all 0.3s ease;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 2px 10px color-mix(in srgb, var(--color-accent-500) 30%, var(--color-neutral-900) 30%);
   z-index: 1000;
 }
 
 .scroll-top:hover {
-  background: #0097a7;
+  background: var(--color-accent-600);
   transform: translateY(-3px);
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 4px 15px color-mix(in srgb, var(--color-accent-500) 45%, var(--color-neutral-900) 35%);
 }
 
 .scroll-top-icon {
@@ -190,7 +172,7 @@ html {
 /* Responsive Design */
 @media (max-width: 768px) {
   .footer {
-    padding: 3rem 1rem 1.5rem;
+    padding: var(--space-xl) var(--space-md) var(--space-md);
   }
 
   .footer-grid {
@@ -242,15 +224,15 @@ html {
   }
 
   .footer-section h3 {
-    color: #000;
+    color: var(--color-neutral-900);
   }
 
   .footer-icon {
-    color: #000;
+    color: var(--color-neutral-900);
   }
 
   .footer-link {
-    color: #000;
+    color: var(--color-neutral-900);
   }
 }
 

--- a/src/css/Header.css
+++ b/src/css/Header.css
@@ -1,36 +1,22 @@
-/* Global Styles */
-* {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
-
-body {
-  font-family: 'Helvetica Neue', sans-serif;
-  background-color: #f4f4f9;
-  color: #333;
-}
-
-/* Header Styles */
 .header {
   position: fixed;
   top: 0;
   left: 0;
   width: 100%;
-  padding: 0.8rem 2rem;
-  background: rgba(255, 255, 255, 0.55);
-  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.10);
-  border-bottom: 1.5px solid rgba(255, 102, 0, 0.10);
+  padding: var(--space-sm) var(--space-xl);
+  background: var(--glass-surface);
+  box-shadow: var(--shadow-soft);
+  border-bottom: 1.5px solid var(--glass-border);
   transition: padding 0.3s, background 0.3s, box-shadow 0.3s, border 0.3s;
   z-index: 1000;
   backdrop-filter: blur(16px) saturate(180%);
 }
 
 .header.scrolled {
-  padding: 0.6rem 2rem;
-  background: rgba(255, 255, 255, 0.85);
-  box-shadow: 0 8px 32px rgba(255, 102, 0, 0.10);
-  border-bottom: 2px solid #ff6600;
+  padding: calc(var(--space-sm) - 0.2rem) var(--space-xl);
+  background: var(--glass-surface-strong);
+  box-shadow: 0 8px 32px var(--glass-highlight);
+  border-bottom: 2px solid var(--color-primary-500);
 }
 
 /* Content Layout */
@@ -47,16 +33,16 @@ body {
   max-height: 48px;
   object-fit: contain;
   border-radius: 50px;
-  background: linear-gradient(90deg, #fffbe6 0%, #ffe0b2 100%);
-  box-shadow: 0 2px 12px rgba(255, 102, 0, 0.08);
-  padding: 0.3rem 1.1rem;
+  background: linear-gradient(90deg, var(--color-neutral-0) 0%, var(--color-primary-100) 100%);
+  box-shadow: 0 2px 12px var(--glass-border);
+  padding: 0.3rem calc(var(--space-md) + 0.1rem);
   transition: transform 0.3s, box-shadow 0.3s;
-  border: 2px solid #ff6600;
+  border: 2px solid var(--color-primary-500);
 }
 
 .logo:hover {
   transform: scale(1.08) rotate(-2deg);
-  box-shadow: 0 4px 24px rgba(255, 102, 0, 0.18);
+  box-shadow: 0 4px 24px var(--glass-highlight);
 }
 
 /* Navigation Links */
@@ -66,7 +52,7 @@ body {
 }
 
 .nav-link {
-  color: #ff6600;
+  color: var(--color-primary-500);
   text-decoration: none;
   font-size: 1.13rem;
   font-weight: 700;
@@ -82,9 +68,9 @@ body {
 }
 
 .nav-link:hover, .nav-link:focus {
-  color: #fff;
-  background: linear-gradient(90deg, #ff6600 0%, #ffcc00 100%);
-  box-shadow: 0 2px 12px rgba(255, 102, 0, 0.10);
+  color: var(--color-neutral-0);
+  background: linear-gradient(90deg, var(--color-primary-500) 0%, var(--color-primary-200) 100%);
+  box-shadow: 0 2px 12px var(--glass-border);
 }
 
 .nav-link::after {
@@ -95,7 +81,7 @@ body {
   bottom: 7px;
   width: 0;
   height: 3px;
-  background: linear-gradient(90deg, #ff6600, #ffcc00);
+  background: linear-gradient(90deg, var(--color-primary-500), var(--color-primary-200));
   border-radius: 2px;
   transition: width 0.35s cubic-bezier(0.4,0,0.2,1), left 0.35s cubic-bezier(0.4,0,0.2,1);
 }
@@ -108,7 +94,7 @@ body {
 /* Responsive Styles */
 @media (max-width: 768px) {
   .header {
-    padding: 1rem;
+    padding: var(--space-md);
   }
   .header-content {
     flex-direction: column;

--- a/src/css/Projects.css
+++ b/src/css/Projects.css
@@ -2,9 +2,13 @@
 #projects {
   padding: 4rem 1.5rem 3rem;
   text-align: center;
-  background: linear-gradient(135deg, #f7faff 0%, #e3f2fd 100%);
+  background: linear-gradient(
+    135deg,
+    var(--color-neutral-50) 0%,
+    color-mix(in srgb, var(--color-accent-100) 45%, var(--color-neutral-0)) 100%
+  );
   border-radius: 18px;
-  box-shadow: 0 8px 32px rgba(0,0,0,0.07);
+  box-shadow: var(--shadow-strong);
   margin: 2rem auto;
   max-width: 1400px;
 }
@@ -12,7 +16,7 @@
 #projects h2 {
   font-size: 2.4rem;
   font-weight: 800;
-  color: #ff6600;
+  color: var(--color-primary-500);
   margin-bottom: 2.5rem;
   letter-spacing: 1.5px;
   position: relative;
@@ -26,11 +30,11 @@
 }
 
 .project-item {
-  background: rgba(255,255,255,0.75);
+  background: color-mix(in srgb, var(--color-neutral-0) 80%, transparent);
   border-radius: 20px;
-  box-shadow: 0 6px 24px rgba(255,102,0,0.07);
+  box-shadow: 0 6px 24px color-mix(in srgb, var(--color-primary-500) 12%, transparent);
   backdrop-filter: blur(8px);
-  border: 1.5px solid rgba(255,102,0,0.08);
+  border: 1.5px solid color-mix(in srgb, var(--color-primary-500) 15%, transparent);
   padding: 2.2rem 1.5rem 1.5rem 1.5rem;
   transition: transform 0.35s cubic-bezier(0.4,0,0.2,1), box-shadow 0.35s, border 0.35s;
   text-align: left;
@@ -50,21 +54,21 @@
   left: 0;
   width: 100%;
   height: 6px;
-  background: linear-gradient(90deg, #ff6600 0%, #ffcc00 100%);
+  background: linear-gradient(90deg, var(--color-primary-500) 0%, var(--color-primary-highlight) 100%);
   border-radius: 20px 20px 0 0;
   opacity: 0.85;
 }
 
 .project-item:hover {
   transform: translateY(-8px) scale(1.025);
-  box-shadow: 0 12px 36px rgba(255,102,0,0.13);
-  border: 1.5px solid #ff6600;
+  box-shadow: 0 12px 36px color-mix(in srgb, var(--color-primary-500) 20%, transparent);
+  border: 1.5px solid var(--color-primary-500);
 }
 
 .project-item h3 {
   font-size: 1.35rem;
   font-weight: 700;
-  color: #222;
+  color: var(--color-neutral-800);
   margin-bottom: 0.7rem;
   margin-top: 0.7rem;
   position: relative;
@@ -77,14 +81,14 @@
   display: block;
   width: 38px;
   height: 3px;
-  background: #ff6600;
+  background: var(--color-primary-500);
   border-radius: 2px;
   margin-top: 0.4rem;
 }
 
 .project-description {
   font-size: 1.01rem;
-  color: #444;
+  color: var(--color-neutral-600);
   line-height: 1.7;
   margin: 1.1rem 0 0.7rem 0;
   padding-left: 1.1rem;
@@ -105,14 +109,14 @@
 }
 
 .tech-item {
-  background: linear-gradient(90deg, #ff6600 0%, #ffcc00 100%);
-  color: #fff;
+  background: linear-gradient(90deg, var(--color-primary-500) 0%, var(--color-primary-highlight) 100%);
+  color: var(--color-neutral-0);
   font-size: 0.87rem;
   padding: 0.32rem 1.1rem;
   border-radius: 16px;
   font-weight: 600;
   letter-spacing: 0.5px;
-  box-shadow: 0 2px 8px rgba(255,102,0,0.07);
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--color-primary-500) 15%, transparent);
   border: none;
   transition: background 0.3s, color 0.3s, box-shadow 0.3s;
   cursor: default;
@@ -120,9 +124,9 @@
 }
 
 .tech-item:hover {
-  background: linear-gradient(90deg, #ffcc00 0%, #ff6600 100%);
-  color: #fffbe6;
-  box-shadow: 0 4px 16px rgba(255,102,0,0.13);
+  background: linear-gradient(90deg, var(--color-primary-highlight) 0%, var(--color-primary-500) 100%);
+  color: var(--color-primary-soft);
+  box-shadow: 0 4px 16px color-mix(in srgb, var(--color-primary-500) 20%, transparent);
 }
 
 /* Responsive Layout */

--- a/src/css/skills.css
+++ b/src/css/skills.css
@@ -2,9 +2,9 @@
 #skills {
   padding: 4rem 2rem;
   text-align: center;
-  background: linear-gradient(135deg, #f7faff 0%, #e0f7fa 100%);
+  background: linear-gradient(135deg, var(--color-neutral-50) 0%, color-mix(in srgb, var(--color-accent-50) 60%, var(--color-neutral-0)) 100%);
   border-radius: 20px;
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.08);
+  box-shadow: var(--shadow-strong);
   max-width: 1200px;
   margin: 2rem auto;
 }
@@ -12,7 +12,7 @@
 #skills h2 {
   font-size: 2.5rem;
   margin-bottom: 2.5rem;
-  color: #ff6600;
+  color: var(--color-primary-500);
   font-weight: 800;
   text-transform: uppercase;
   letter-spacing: 1.5px;
@@ -26,7 +26,7 @@
 
 .skills-category-title {
   font-size: 1.6rem;
-  color: #007bff;
+  color: var(--color-accent-500);
   font-weight: bold;
   text-transform: uppercase;
   margin-bottom: 1.5rem;
@@ -40,7 +40,7 @@
   display: block;
   width: 48px;
   height: 4px;
-  background: linear-gradient(90deg, #ff6600, #ffcc00);
+  background: linear-gradient(90deg, var(--color-primary-500), var(--color-primary-highlight));
   border-radius: 2px;
   margin: 0.7rem auto 0 auto;
 }
@@ -58,9 +58,9 @@
   align-items: center;
   padding: 1.1rem 1.7rem;
   border-radius: 18px;
-  background: rgba(255,255,255,0.7);
-  box-shadow: 0 4px 18px rgba(0,0,0,0.10);
-  border: 1.5px solid rgba(255,102,0,0.10);
+  background: color-mix(in srgb, var(--color-neutral-0) 75%, transparent);
+  box-shadow: 0 4px 18px color-mix(in srgb, var(--color-primary-500) 12%, var(--color-neutral-900) 12%);
+  border: 1.5px solid color-mix(in srgb, var(--color-primary-500) 15%, transparent);
   cursor: pointer;
   transition: transform 0.35s cubic-bezier(0.4,0,0.2,1), box-shadow 0.35s, border 0.35s, background 0.35s;
   min-width: 180px;
@@ -72,30 +72,30 @@
 
 .skill-item:hover, .skill-item:focus {
   transform: translateY(-8px) scale(1.05);
-  box-shadow: 0 8px 28px rgba(255,102,0,0.13);
-  border: 1.5px solid #ff6600;
-  background: rgba(255,255,255,0.95);
+  box-shadow: 0 8px 28px color-mix(in srgb, var(--color-primary-500) 20%, transparent);
+  border: 1.5px solid var(--color-primary-500);
+  background: color-mix(in srgb, var(--color-neutral-0) 95%, transparent);
   outline: none;
 }
 
 .skill-icon {
   font-size: 2.2rem;
   margin-right: 1rem;
-  color: var(--skill-bg-color, #ff6600);
+  color: var(--skill-bg-color, var(--color-primary-500));
   transition: transform 0.5s cubic-bezier(0.4,0,0.2,1), color 0.4s;
 }
 
 .skill-item:hover .skill-icon, .skill-item:focus .skill-icon {
   transform: rotate(-8deg) scale(1.18);
-  color: #ff6600;
+  color: var(--color-primary-500);
 }
 
 .skill-name {
   font-size: 1.18rem;
   font-weight: bold;
   letter-spacing: 0.5px;
-  color: #333;
-  text-shadow: 0 1px 4px rgba(255,102,0,0.04);
+  color: var(--color-neutral-700);
+  text-shadow: 0 1px 4px color-mix(in srgb, var(--color-primary-500) 12%, transparent);
 }
 
 /* Responsive Design */

--- a/src/css/theme.css
+++ b/src/css/theme.css
@@ -1,0 +1,237 @@
+/* Global theme tokens */
+:root {
+  color-scheme: light;
+
+  /* Color palette */
+  --color-primary-50: #fff4e6;
+  --color-primary-100: #ffe0b2;
+  --color-primary-200: #ffcc80;
+  --color-primary-300: #ffb74d;
+  --color-primary-400: #ff8800;
+  --color-primary-500: #ff6600;
+  --color-primary-600: #e05500;
+  --color-primary-700: #b34700;
+  --color-primary-highlight: #ffcc00;
+  --color-primary-soft: #fffbe6;
+
+  --color-accent-50: #e0f7fa;
+  --color-accent-100: #b2ebf2;
+  --color-accent-200: #80deea;
+  --color-accent-300: #4dd0e1;
+  --color-accent-400: #26c6da;
+  --color-accent-500: #00bcd4;
+  --color-accent-600: #0097a7;
+
+  --color-neutral-0: #ffffff;
+  --color-neutral-50: #f8f9fa;
+  --color-neutral-100: #f4f4f9;
+  --color-neutral-200: #e9ecef;
+  --color-neutral-300: #dee2e6;
+  --color-neutral-400: #ced4da;
+  --color-neutral-500: #adb5bd;
+  --color-neutral-600: #6c757d;
+  --color-neutral-700: #495057;
+  --color-neutral-800: #343a40;
+  --color-neutral-900: #212529;
+
+  --surface-base: var(--color-neutral-0);
+  --surface-muted: var(--color-neutral-100);
+  --surface-strong: var(--color-neutral-900);
+  --surface-inverse: var(--color-neutral-900);
+  --text-on-inverse: var(--color-neutral-0);
+
+  /* Typography */
+  --font-family-base: "Inter", "Helvetica Neue", Arial, sans-serif;
+  --font-family-heading: "Poppins", "Segoe UI", sans-serif;
+  --font-size-sm: 0.875rem;
+  --font-size-base: 1rem;
+  --font-size-lg: 1.125rem;
+  --font-size-xl: 1.5rem;
+  --line-height-base: 1.6;
+
+  /* Spacing scale */
+  --space-2xs: 0.25rem;
+  --space-xs: 0.5rem;
+  --space-sm: 0.75rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2rem;
+  --space-2xl: 3rem;
+
+  --border-radius-sm: 6px;
+  --border-radius-md: 12px;
+  --border-radius-lg: 20px;
+
+  --shadow-soft: 0 6px 24px rgba(0, 0, 0, 0.1);
+  --shadow-strong: 0 12px 40px rgba(0, 0, 0, 0.15);
+
+  --body-background: var(--surface-muted);
+  --body-color: var(--color-neutral-800);
+
+  --glass-surface: rgba(255, 255, 255, 0.55);
+  --glass-surface-strong: rgba(255, 255, 255, 0.85);
+  --glass-border: rgba(255, 102, 0, 0.1);
+  --glass-highlight: rgba(255, 102, 0, 0.18);
+
+  --text-muted: var(--color-neutral-600);
+  --text-muted-inverse: rgba(255, 255, 255, 0.7);
+
+  --color-success: #28a745;
+  --color-warning: #ffd700;
+  --color-danger: #dc3545;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+
+  --color-primary-50: #3b1d00;
+  --color-primary-100: #552600;
+  --color-primary-200: #7a3400;
+  --color-primary-300: #a24300;
+  --color-primary-400: #c45300;
+  --color-primary-500: #ff7a1c;
+  --color-primary-600: #ff944d;
+  --color-primary-700: #ffb273;
+  --color-primary-highlight: #ffb347;
+  --color-primary-soft: #40301f;
+
+  --color-accent-50: #013036;
+  --color-accent-100: #014b55;
+  --color-accent-200: #026b78;
+  --color-accent-300: #03889a;
+  --color-accent-400: #05a4b9;
+  --color-accent-500: #0fc0d6;
+  --color-accent-600: #3cd4e5;
+
+  --color-neutral-0: #0f1115;
+  --color-neutral-50: #15181f;
+  --color-neutral-100: #1d2029;
+  --color-neutral-200: #262a36;
+  --color-neutral-300: #323747;
+  --color-neutral-400: #3f4558;
+  --color-neutral-500: #596073;
+  --color-neutral-600: #747b8c;
+  --color-neutral-700: #9aa1b3;
+  --color-neutral-800: #c7ccdb;
+  --color-neutral-900: #f1f3f8;
+
+  --surface-base: #12141c;
+  --surface-muted: #191c25;
+  --surface-strong: #f1f3f8;
+  --surface-inverse: var(--color-neutral-100);
+  --text-on-inverse: var(--color-neutral-900);
+
+  --shadow-soft: 0 10px 30px rgba(0, 0, 0, 0.45);
+  --shadow-strong: 0 20px 50px rgba(0, 0, 0, 0.55);
+
+  --body-background: var(--surface-base);
+  --body-color: var(--color-neutral-900);
+
+  --glass-surface: rgba(25, 28, 37, 0.75);
+  --glass-surface-strong: rgba(25, 28, 37, 0.9);
+  --glass-border: rgba(255, 122, 28, 0.25);
+  --glass-highlight: rgba(15, 192, 214, 0.35);
+
+  --text-muted: var(--color-neutral-500);
+  --text-muted-inverse: rgba(241, 243, 248, 0.65);
+
+  --color-success: #28a745;
+  --color-warning: #f0c419;
+  --color-danger: #e75a67;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    color-scheme: dark;
+
+    --color-primary-50: #3b1d00;
+    --color-primary-100: #552600;
+    --color-primary-200: #7a3400;
+    --color-primary-300: #a24300;
+    --color-primary-400: #c45300;
+    --color-primary-500: #ff7a1c;
+    --color-primary-600: #ff944d;
+    --color-primary-700: #ffb273;
+    --color-primary-highlight: #ffb347;
+    --color-primary-soft: #40301f;
+
+    --color-accent-50: #013036;
+    --color-accent-100: #014b55;
+    --color-accent-200: #026b78;
+    --color-accent-300: #03889a;
+    --color-accent-400: #05a4b9;
+    --color-accent-500: #0fc0d6;
+    --color-accent-600: #3cd4e5;
+
+    --color-neutral-0: #0f1115;
+    --color-neutral-50: #15181f;
+    --color-neutral-100: #1d2029;
+    --color-neutral-200: #262a36;
+    --color-neutral-300: #323747;
+    --color-neutral-400: #3f4558;
+    --color-neutral-500: #596073;
+    --color-neutral-600: #747b8c;
+    --color-neutral-700: #9aa1b3;
+    --color-neutral-800: #c7ccdb;
+    --color-neutral-900: #f1f3f8;
+
+    --surface-base: #12141c;
+    --surface-muted: #191c25;
+    --surface-strong: #f1f3f8;
+    --surface-inverse: var(--color-neutral-100);
+    --text-on-inverse: var(--color-neutral-900);
+
+    --shadow-soft: 0 10px 30px rgba(0, 0, 0, 0.45);
+    --shadow-strong: 0 20px 50px rgba(0, 0, 0, 0.55);
+
+    --body-background: var(--surface-base);
+    --body-color: var(--color-neutral-900);
+
+    --glass-surface: rgba(25, 28, 37, 0.75);
+    --glass-surface-strong: rgba(25, 28, 37, 0.9);
+    --glass-border: rgba(255, 122, 28, 0.25);
+    --glass-highlight: rgba(15, 192, 214, 0.35);
+
+    --text-muted: var(--color-neutral-500);
+    --text-muted-inverse: rgba(241, 243, 248, 0.65);
+
+    --color-success: #28a745;
+    --color-warning: #f0c419;
+    --color-danger: #e75a67;
+  }
+}
+
+/* CSS Reset */
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: 80px;
+}
+
+body {
+  font-family: var(--font-family-base);
+  background: var(--body-background);
+  color: var(--body-color);
+  line-height: var(--line-height-base);
+  min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+a {
+  color: inherit;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+button {
+  font: inherit;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import "./css/theme.css";
 import App from "./App.jsx";
 
 ReactDOM.createRoot(document.getElementById("root")).render(


### PR DESCRIPTION
## Summary
- introduce a shared theme stylesheet with color, spacing, and typography tokens for light and dark palettes and global resets
- import the theme in the app entry point and update header, footer, and key sections to consume the shared variables and gradients
- refresh component-specific buttons and forms to use the centralized accent and feedback colors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e52aacf2388328ad82fd505426f9ba