### PR TITLE
Make header sticky and prevent section overlap

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -3,6 +3,8 @@ import "../css/Header.css";
 import Logo from "../Logo.png";
 import { Link } from "react-scroll";
 
+const SCROLL_OFFSET = 88; // Keep in sync with --header-height in theme.css
+
 const Header = () => {
   const [scrolled, setScrolled] = useState(false);
 
@@ -23,6 +25,7 @@ const Header = () => {
               to={section.toLowerCase()} // Ensure the target matches the section ID
               smooth={true}
               duration={500}
+              offset={-SCROLL_OFFSET}
               className="nav-link"
             >
               {section}

--- a/src/css/About.css
+++ b/src/css/About.css
@@ -7,7 +7,7 @@
   background: linear-gradient(180deg, var(--color-neutral-0), var(--color-neutral-50));
   transition: background 0.5s ease;
   min-height: 100vh;
-  scroll-margin-top: 80px; /* For smooth scroll behavior */
+  scroll-margin-top: calc(var(--header-height) + var(--space-md)); /* For smooth scroll behavior */
 }
 
 .about-section:hover {

--- a/src/css/Header.css
+++ b/src/css/Header.css
@@ -1,5 +1,5 @@
 .header {
-  position: fixed;
+  position: sticky;
   top: 0;
   left: 0;
   width: 100%;

--- a/src/css/theme.css
+++ b/src/css/theme.css
@@ -58,6 +58,8 @@
   --space-xl: 2rem;
   --space-2xl: 3rem;
 
+  --header-height: 5.5rem;
+
   --border-radius-sm: 6px;
   --border-radius-md: 12px;
   --border-radius-lg: 20px;
@@ -210,7 +212,7 @@
 
 html {
   scroll-behavior: smooth;
-  scroll-padding-top: 80px;
+  scroll-padding-top: var(--header-height);
 }
 
 body {
@@ -221,6 +223,10 @@ body {
   min-height: 100vh;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
+}
+
+section {
+  scroll-margin-top: calc(var(--header-height) + var(--space-sm));
 }
 
 a {


### PR DESCRIPTION
## Summary
- switch the header to a sticky position and ensure nav links apply a matching scroll offset
- introduce a reusable header height token and section scroll margins so content is never hidden under the header

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e59215b35c8328a696087ea99af560